### PR TITLE
feat: Add Grpc Telemetry client interceptor for trace context propagation

### DIFF
--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -256,6 +256,11 @@
       <artifactId>opentelemetry-context</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.opentelemetry.instrumentation</groupId>
+      <artifactId>opentelemetry-grpc-1.6</artifactId>
+      <version>2.1.0-alpha</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
     </dependency>

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DelayedReadContext.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/DelayedReadContext.java
@@ -44,6 +44,11 @@ class DelayedReadContext<T extends ReadContext> implements ReadContext {
     try {
       return this.readContextFuture.get();
     } catch (ExecutionException executionException) {
+      // Propagate the underlying exception as a RuntimeException (SpannerException is also a
+      // RuntimeException).
+      if (executionException.getCause() instanceof RuntimeException) {
+        throw (RuntimeException) executionException.getCause();
+      }
       throw SpannerExceptionFactory.asSpannerException(executionException.getCause());
     } catch (InterruptedException interruptedException) {
       throw SpannerExceptionFactory.propagateInterrupt(interruptedException);

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerInterceptorProvider.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerInterceptorProvider.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import io.grpc.ClientInterceptor;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -51,6 +52,8 @@ public class SpannerInterceptorProvider implements GrpcInterceptorProvider {
     defaultInterceptorList.add(
         new LoggingInterceptor(Logger.getLogger(GapicSpannerRpc.class.getName()), Level.FINER));
     defaultInterceptorList.add(new HeaderInterceptor(new SpannerRpcMetrics(openTelemetry)));
+    defaultInterceptorList.add(GrpcTelemetry.create(openTelemetry).newClientInterceptor());
+    System.out.println("setting the client interceptor");
     return new SpannerInterceptorProvider(ImmutableList.copyOf(defaultInterceptorList));
   }
 

--- a/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerInterceptorProvider.java
+++ b/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/SpannerInterceptorProvider.java
@@ -53,7 +53,6 @@ public class SpannerInterceptorProvider implements GrpcInterceptorProvider {
         new LoggingInterceptor(Logger.getLogger(GapicSpannerRpc.class.getName()), Level.FINER));
     defaultInterceptorList.add(new HeaderInterceptor(new SpannerRpcMetrics(openTelemetry)));
     defaultInterceptorList.add(GrpcTelemetry.create(openTelemetry).newClientInterceptor());
-    System.out.println("setting the client interceptor");
     return new SpannerInterceptorProvider(ImmutableList.copyOf(defaultInterceptorList));
   }
 

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/OpenTelemetryTracingTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/OpenTelemetryTracingTest.java
@@ -447,6 +447,9 @@ public class OpenTelemetryTracingTest extends AbstractMockServerTest {
             .filter(span -> span.getName().equals("CloudSpannerJdbc.ReadWriteTransaction"))
             .findFirst()
             .orElseThrow(IllegalStateException::new);
+    assertEquals(
+        Boolean.TRUE,
+        transactionSpan.getAttributes().get(AttributeKey.booleanKey("transaction.retried")));
     assertEquals(1, transactionSpan.getTotalRecordedEvents());
     EventData event = transactionSpan.getEvents().get(0);
     assertEquals(


### PR DESCRIPTION
For End to end tracing feature, `traceparent` header is required on the Spanner layer in all the requests. This change help in passing `traceparent` header inside Spanner requests if Context propagators are setup in OpenTelemetrySdk.